### PR TITLE
feat: setup base architecture with navigation, theme, and use cases

### DIFF
--- a/app/src/main/kotlin/com/giruai/climatest/MainActivity.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/MainActivity.kt
@@ -3,15 +3,12 @@ package com.giruai.climatest
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.giruai.climatest.presentation.navigation.ClimaNavGraph
+import com.giruai.climatest.presentation.theme.ClimaTestTheme
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
@@ -20,42 +17,16 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Timber.d("MainActivity onCreate")
-        
+
         setContent {
             ClimaTestTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    PlaceholderScreen()
+                    ClimaNavGraph()
                 }
             }
         }
-    }
-}
-
-@Composable
-fun PlaceholderScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = "ClimaApp",
-            style = MaterialTheme.typography.displayLarge
-        )
-    }
-}
-
-@Composable
-fun ClimaTestTheme(content: @Composable () -> Unit) {
-    MaterialTheme(content = content)
-}
-
-@Preview(showBackground = true)
-@Composable
-fun PlaceholderScreenPreview() {
-    ClimaTestTheme {
-        PlaceholderScreen()
     }
 }

--- a/app/src/main/kotlin/com/giruai/climatest/data/local/preferences/SettingsManager.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/data/local/preferences/SettingsManager.kt
@@ -1,0 +1,59 @@
+package com.giruai.climatest.data.local.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class TemperatureUnit(val symbol: String) {
+    CELSIUS("°C"),
+    FAHRENHEIT("°F")
+}
+
+enum class WindUnit(val symbol: String) {
+    KMH("km/h"),
+    MPH("mph")
+}
+
+data class UserSettings(
+    val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
+    val windUnit: WindUnit = WindUnit.KMH
+)
+
+@Singleton
+class SettingsManager @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("clima_settings", Context.MODE_PRIVATE)
+
+    private val _settings = MutableStateFlow(loadSettings())
+    val settings: StateFlow<UserSettings> = _settings.asStateFlow()
+
+    fun setTemperatureUnit(unit: TemperatureUnit) {
+        prefs.edit().putString(KEY_TEMP_UNIT, unit.name).apply()
+        _settings.value = _settings.value.copy(temperatureUnit = unit)
+    }
+
+    fun setWindUnit(unit: WindUnit) {
+        prefs.edit().putString(KEY_WIND_UNIT, unit.name).apply()
+        _settings.value = _settings.value.copy(windUnit = unit)
+    }
+
+    private fun loadSettings(): UserSettings {
+        val tempUnit = prefs.getString(KEY_TEMP_UNIT, TemperatureUnit.CELSIUS.name)
+            ?.let { TemperatureUnit.valueOf(it) } ?: TemperatureUnit.CELSIUS
+        val windUnit = prefs.getString(KEY_WIND_UNIT, WindUnit.KMH.name)
+            ?.let { WindUnit.valueOf(it) } ?: WindUnit.KMH
+        return UserSettings(temperatureUnit = tempUnit, windUnit = windUnit)
+    }
+
+    companion object {
+        private const val KEY_TEMP_UNIT = "temperature_unit"
+        private const val KEY_WIND_UNIT = "wind_unit"
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/usecase/AddFavoriteUseCase.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/usecase/AddFavoriteUseCase.kt
@@ -1,0 +1,22 @@
+package com.giruai.climatest.domain.usecase
+
+import com.giruai.climatest.domain.model.City
+import com.giruai.climatest.domain.repository.FavoritesRepository
+import javax.inject.Inject
+
+class AddFavoriteUseCase @Inject constructor(
+    private val repository: FavoritesRepository
+) {
+    suspend operator fun invoke(city: City): Result<Unit> {
+        val count = repository.count()
+        if (count >= MAX_FAVORITES) {
+            return Result.failure(Exception("Maximum of $MAX_FAVORITES favorites reached"))
+        }
+        repository.add(city)
+        return Result.success(Unit)
+    }
+
+    companion object {
+        const val MAX_FAVORITES = 10
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/usecase/GetCurrentWeatherUseCase.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/usecase/GetCurrentWeatherUseCase.kt
@@ -1,0 +1,12 @@
+package com.giruai.climatest.domain.usecase
+
+import com.giruai.climatest.domain.model.CurrentWeather
+import com.giruai.climatest.domain.repository.WeatherRepository
+import javax.inject.Inject
+
+class GetCurrentWeatherUseCase @Inject constructor(
+    private val repository: WeatherRepository
+) {
+    suspend operator fun invoke(latitude: Double, longitude: Double): Result<CurrentWeather> =
+        repository.getCurrentWeather(latitude, longitude)
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/usecase/GetFavoritesUseCase.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/usecase/GetFavoritesUseCase.kt
@@ -1,0 +1,12 @@
+package com.giruai.climatest.domain.usecase
+
+import com.giruai.climatest.domain.model.City
+import com.giruai.climatest.domain.repository.FavoritesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetFavoritesUseCase @Inject constructor(
+    private val repository: FavoritesRepository
+) {
+    operator fun invoke(): Flow<List<City>> = repository.getAll()
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/usecase/GetForecastUseCase.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/usecase/GetForecastUseCase.kt
@@ -1,0 +1,12 @@
+package com.giruai.climatest.domain.usecase
+
+import com.giruai.climatest.domain.model.DailyForecast
+import com.giruai.climatest.domain.repository.WeatherRepository
+import javax.inject.Inject
+
+class GetForecastUseCase @Inject constructor(
+    private val repository: WeatherRepository
+) {
+    suspend operator fun invoke(latitude: Double, longitude: Double): Result<List<DailyForecast>> =
+        repository.getForecast(latitude, longitude)
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/usecase/RemoveFavoriteUseCase.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/usecase/RemoveFavoriteUseCase.kt
@@ -1,0 +1,10 @@
+package com.giruai.climatest.domain.usecase
+
+import com.giruai.climatest.domain.repository.FavoritesRepository
+import javax.inject.Inject
+
+class RemoveFavoriteUseCase @Inject constructor(
+    private val repository: FavoritesRepository
+) {
+    suspend operator fun invoke(cityId: Long) = repository.remove(cityId)
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/usecase/SearchCitiesUseCase.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/usecase/SearchCitiesUseCase.kt
@@ -1,0 +1,14 @@
+package com.giruai.climatest.domain.usecase
+
+import com.giruai.climatest.domain.model.City
+import com.giruai.climatest.domain.repository.WeatherRepository
+import javax.inject.Inject
+
+class SearchCitiesUseCase @Inject constructor(
+    private val repository: WeatherRepository
+) {
+    suspend operator fun invoke(query: String): Result<List<City>> {
+        if (query.length < 2) return Result.success(emptyList())
+        return repository.searchCities(query)
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/navigation/NavGraph.kt
@@ -1,0 +1,86 @@
+package com.giruai.climatest.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.giruai.climatest.presentation.screen.favorites.FavoritesScreen
+import com.giruai.climatest.presentation.screen.search.SearchScreen
+import com.giruai.climatest.presentation.screen.settings.SettingsScreen
+import com.giruai.climatest.presentation.screen.weather.WeatherScreen
+
+object Routes {
+    const val WEATHER = "weather"
+    const val SEARCH = "search"
+    const val FAVORITES = "favorites"
+    const val SETTINGS = "settings"
+
+    fun weatherWithArgs(lat: Double? = null, lon: Double? = null): String {
+        return if (lat != null && lon != null) {
+            "$WEATHER?lat=$lat&lon=$lon"
+        } else {
+            WEATHER
+        }
+    }
+}
+
+@Composable
+fun ClimaNavGraph(
+    navController: NavHostController = rememberNavController()
+) {
+    NavHost(
+        navController = navController,
+        startDestination = Routes.WEATHER
+    ) {
+        composable(
+            route = "${Routes.WEATHER}?lat={lat}&lon={lon}",
+            arguments = listOf(
+                navArgument("lat") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+                navArgument("lon") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
+        ) {
+            WeatherScreen(
+                onNavigateToSearch = { navController.navigate(Routes.SEARCH) },
+                onNavigateToFavorites = { navController.navigate(Routes.FAVORITES) },
+                onNavigateToSettings = { navController.navigate(Routes.SETTINGS) }
+            )
+        }
+
+        composable(route = Routes.SEARCH) {
+            SearchScreen(
+                onCitySelected = { cityId, lat, lon ->
+                    navController.navigate(Routes.weatherWithArgs(lat, lon)) {
+                        popUpTo(Routes.WEATHER) { inclusive = true }
+                    }
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(route = Routes.FAVORITES) {
+            FavoritesScreen(
+                onCitySelected = { cityId, lat, lon ->
+                    navController.navigate(Routes.weatherWithArgs(lat, lon))
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(route = Routes.SETTINGS) {
+            SettingsScreen(
+                onBack = { navController.popBackStack() }
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/favorites/FavoritesScreen.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/favorites/FavoritesScreen.kt
@@ -1,0 +1,26 @@
+package com.giruai.climatest.presentation.screen.favorites
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun FavoritesScreen(
+    onCitySelected: (Long, Double, Double) -> Unit,
+    onBack: () -> Unit
+) {
+    // Placeholder - will be implemented in S4.3
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Favorites Screen",
+            style = MaterialTheme.typography.headlineLarge
+        )
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/search/SearchScreen.kt
@@ -1,0 +1,26 @@
+package com.giruai.climatest.presentation.screen.search
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SearchScreen(
+    onCitySelected: (Long, Double, Double) -> Unit,
+    onBack: () -> Unit
+) {
+    // Placeholder - will be implemented in S3.2
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Search Screen",
+            style = MaterialTheme.typography.headlineLarge
+        )
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/settings/SettingsScreen.kt
@@ -1,0 +1,25 @@
+package com.giruai.climatest.presentation.screen.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit
+) {
+    // Placeholder - will be implemented in S5.2
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Settings Screen",
+            style = MaterialTheme.typography.headlineLarge
+        )
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherScreen.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherScreen.kt
@@ -1,0 +1,27 @@
+package com.giruai.climatest.presentation.screen.weather
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun WeatherScreen(
+    onNavigateToSearch: () -> Unit,
+    onNavigateToFavorites: () -> Unit,
+    onNavigateToSettings: () -> Unit
+) {
+    // Placeholder - will be implemented in S2.3
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Weather Screen",
+            style = MaterialTheme.typography.headlineLarge
+        )
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/theme/Color.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/theme/Color.kt
@@ -1,0 +1,35 @@
+package com.giruai.climatest.presentation.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Light Theme
+val md_theme_light_primary = Color(0xFF1565C0)
+val md_theme_light_onPrimary = Color(0xFFFFFFFF)
+val md_theme_light_primaryContainer = Color(0xFFD1E4FF)
+val md_theme_light_onPrimaryContainer = Color(0xFF001D36)
+val md_theme_light_secondary = Color(0xFF535F70)
+val md_theme_light_onSecondary = Color(0xFFFFFFFF)
+val md_theme_light_secondaryContainer = Color(0xFFD7E3F7)
+val md_theme_light_onSecondaryContainer = Color(0xFF101C2B)
+val md_theme_light_background = Color(0xFFFDFCFF)
+val md_theme_light_onBackground = Color(0xFF1A1C1E)
+val md_theme_light_surface = Color(0xFFFDFCFF)
+val md_theme_light_onSurface = Color(0xFF1A1C1E)
+val md_theme_light_error = Color(0xFFBA1A1A)
+val md_theme_light_onError = Color(0xFFFFFFFF)
+
+// Dark Theme
+val md_theme_dark_primary = Color(0xFF9ECAFF)
+val md_theme_dark_onPrimary = Color(0xFF003258)
+val md_theme_dark_primaryContainer = Color(0xFF00497D)
+val md_theme_dark_onPrimaryContainer = Color(0xFFD1E4FF)
+val md_theme_dark_secondary = Color(0xFFBBC7DB)
+val md_theme_dark_onSecondary = Color(0xFF253140)
+val md_theme_dark_secondaryContainer = Color(0xFF3B4858)
+val md_theme_dark_onSecondaryContainer = Color(0xFFD7E3F7)
+val md_theme_dark_background = Color(0xFF1A1C1E)
+val md_theme_dark_onBackground = Color(0xFFE2E2E6)
+val md_theme_dark_surface = Color(0xFF1A1C1E)
+val md_theme_dark_onSurface = Color(0xFFE2E2E6)
+val md_theme_dark_error = Color(0xFFFFB4AB)
+val md_theme_dark_onError = Color(0xFF690005)

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/theme/Theme.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/theme/Theme.kt
@@ -1,0 +1,67 @@
+package com.giruai.climatest.presentation.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+private val LightColorScheme = lightColorScheme(
+    primary = md_theme_light_primary,
+    onPrimary = md_theme_light_onPrimary,
+    primaryContainer = md_theme_light_primaryContainer,
+    onPrimaryContainer = md_theme_light_onPrimaryContainer,
+    secondary = md_theme_light_secondary,
+    onSecondary = md_theme_light_onSecondary,
+    secondaryContainer = md_theme_light_secondaryContainer,
+    onSecondaryContainer = md_theme_light_onSecondaryContainer,
+    background = md_theme_light_background,
+    onBackground = md_theme_light_onBackground,
+    surface = md_theme_light_surface,
+    onSurface = md_theme_light_onSurface,
+    error = md_theme_light_error,
+    onError = md_theme_light_onError,
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = md_theme_dark_primary,
+    onPrimary = md_theme_dark_onPrimary,
+    primaryContainer = md_theme_dark_primaryContainer,
+    onPrimaryContainer = md_theme_dark_onPrimaryContainer,
+    secondary = md_theme_dark_secondary,
+    onSecondary = md_theme_dark_onSecondary,
+    secondaryContainer = md_theme_dark_secondaryContainer,
+    onSecondaryContainer = md_theme_dark_onSecondaryContainer,
+    background = md_theme_dark_background,
+    onBackground = md_theme_dark_onBackground,
+    surface = md_theme_dark_surface,
+    onSurface = md_theme_dark_onSurface,
+    error = md_theme_dark_error,
+    onError = md_theme_dark_onError,
+)
+
+@Composable
+fun ClimaTestTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/theme/Type.kt
@@ -1,0 +1,53 @@
+package com.giruai.climatest.presentation.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    displayLarge = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 45.sp,
+        lineHeight = 52.sp
+    ),
+    headlineLarge = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 32.sp,
+        lineHeight = 40.sp
+    ),
+    headlineMedium = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 36.sp
+    ),
+    titleLarge = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        lineHeight = 28.sp
+    ),
+    bodyLarge = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    ),
+    bodyMedium = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    labelLarge = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    )
+)


### PR DESCRIPTION
## S1.3: Setup Base Architecture

### Changes
- **Material 3 Theme**: Light/dark color schemes, dynamic colors (API 31+), typography scales
- **Compose Navigation**: NavGraph with weather/search/favorites/settings routes
- **Placeholder screens**: All 4 destinations ready for implementation
- **Use Cases**: GetCurrentWeather, GetForecast, SearchCities, GetFavorites, AddFavorite (max 10), RemoveFavorite
- **SettingsManager**: SharedPreferences with StateFlow for reactive unit preferences (°C/°F, km/h/mph)
- **MainActivity**: Updated to use ClimaTestTheme + ClimaNavGraph

### Build
- `assembleDebug` ✅ SUCCESS

### ACs
- [x] Package structure matches architecture doc
- [x] Domain models created (City, CurrentWeather, DailyForecast)
- [x] Repository interfaces defined
- [x] Base ViewModel and UiState pattern established
- [x] MainActivity with Compose setup
- [x] NavGraph stub with placeholder screens