### PR TITLE
feat: implement location provider with FusedLocationProvider

### DIFF
--- a/app/src/main/kotlin/com/giruai/climatest/data/location/FusedLocationProviderImpl.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/data/location/FusedLocationProviderImpl.kt
@@ -1,0 +1,100 @@
+package com.giruai.climatest.data.location
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.giruai.climatest.domain.location.Location
+import com.giruai.climatest.domain.location.LocationProvider
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.CancellationTokenSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeout
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FusedLocationProviderImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : LocationProvider {
+
+    private val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+
+    override suspend fun getCurrentLocation(): Result<Location> {
+        if (!hasPermission()) {
+            Timber.w("Location permission not granted")
+            return Result.failure(SecurityException("Location permission not granted"))
+        }
+
+        return try {
+            withTimeout(LOCATION_TIMEOUT_MS) {
+                val cancellationToken = CancellationTokenSource()
+                
+                @Suppress("MissingPermission")
+                val androidLocation = fusedClient.getCurrentLocation(
+                    Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                    cancellationToken.token
+                ).await()
+
+                if (androidLocation != null) {
+                    Timber.d("Location obtained: ${androidLocation.latitude}, ${androidLocation.longitude}")
+                    Result.success(
+                        Location(
+                            latitude = androidLocation.latitude,
+                            longitude = androidLocation.longitude
+                        )
+                    )
+                } else {
+                    Timber.w("Location was null, trying last known location")
+                    getLastKnownLocation()
+                }
+            }
+        } catch (e: TimeoutCancellationException) {
+            Timber.e(e, "Location timeout after ${LOCATION_TIMEOUT_MS}ms")
+            Result.failure(Exception("Location request timed out after ${LOCATION_TIMEOUT_MS / 1000}s"))
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to get location")
+            Result.failure(e)
+        }
+    }
+
+    @Suppress("MissingPermission")
+    private suspend fun getLastKnownLocation(): Result<Location> {
+        return try {
+            val lastLocation = fusedClient.lastLocation.await()
+            if (lastLocation != null) {
+                Timber.d("Using last known location: ${lastLocation.latitude}, ${lastLocation.longitude}")
+                Result.success(
+                    Location(
+                        latitude = lastLocation.latitude,
+                        longitude = lastLocation.longitude
+                    )
+                )
+            } else {
+                Result.failure(Exception("No location available. Please enable location services."))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to get last known location")
+            Result.failure(e)
+        }
+    }
+
+    override fun hasPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    companion object {
+        private const val LOCATION_TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/di/AppModule.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/di/AppModule.kt
@@ -1,0 +1,38 @@
+package com.giruai.climatest.di
+
+import android.content.Context
+import com.giruai.climatest.data.local.preferences.SettingsManager
+import com.giruai.climatest.data.location.FusedLocationProviderImpl
+import com.giruai.climatest.domain.location.LocationProvider
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideContext(@ApplicationContext context: Context): Context = context
+
+    @Provides
+    @Singleton
+    fun provideSettingsManager(@ApplicationContext context: Context): SettingsManager =
+        SettingsManager(context)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocationModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindLocationProvider(
+        impl: FusedLocationProviderImpl
+    ): LocationProvider
+}

--- a/app/src/main/kotlin/com/giruai/climatest/domain/location/LocationProvider.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/domain/location/LocationProvider.kt
@@ -1,0 +1,11 @@
+package com.giruai.climatest.domain.location
+
+data class Location(
+    val latitude: Double,
+    val longitude: Double
+)
+
+interface LocationProvider {
+    suspend fun getCurrentLocation(): Result<Location>
+    fun hasPermission(): Boolean
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/util/PermissionHandler.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/util/PermissionHandler.kt
@@ -1,0 +1,75 @@
+package com.giruai.climatest.presentation.util
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import timber.log.Timber
+
+object PermissionUtils {
+    
+    fun hasLocationPermission(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+    }
+
+    fun openAppSettings(context: Context) {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(intent)
+    }
+}
+
+class LocationPermissionHandler(
+    private val activity: ComponentActivity,
+    private val onPermissionResult: (Boolean) -> Unit
+) {
+    private var permissionLauncher: ActivityResultLauncher<Array<String>>? = null
+
+    init {
+        permissionLauncher = activity.registerForActivityResult(
+            ActivityResultContracts.RequestMultiplePermissions()
+        ) { permissions ->
+            val granted = permissions.values.any { it }
+            Timber.d("Location permission result: $granted")
+            onPermissionResult(granted)
+        }
+    }
+
+    fun requestPermission() {
+        Timber.d("Requesting location permission")
+        permissionLauncher?.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+    }
+
+    fun hasPermission(): Boolean {
+        return PermissionUtils.hasLocationPermission(activity)
+    }
+}
+
+@Composable
+fun rememberLocationPermissionHandler(
+    onPermissionResult: (Boolean) -> Unit
+): LocationPermissionHandler {
+    val context = LocalContext.current as ComponentActivity
+    return LocationPermissionHandler(context, onPermissionResult)
+}


### PR DESCRIPTION
## S2.1: Implement Location Provider

Resolves #6

### Changes
- **LocationProvider interface**: Result-based API with getCurrentLocation()
- **FusedLocationProviderImpl**: Uses Google Play Services FusedLocationProviderClient
  - 10s timeout with cancellation token
  - Fallback to last known location if current fails
  - Proper permission checking (FINE + COARSE)
- **LocationPermissionHandler**: Compose-friendly permission request wrapper
- **PermissionUtils**: Helper for permission checks + app settings navigation
- **Hilt DI**: AppModule + LocationModule for dependency injection

### Build
- `assembleDebug` ✅ SUCCESS

### Acceptance Criteria
- [x] FusedLocationProvider returns lat/lon when granted
- [x] Location timeout (10s) handled gracefully
- [x] Permission checking implemented
- [ ] Permission dialog flow (requires WeatherViewModel integration)
- [ ] Denied permission fallback message (requires WeatherScreen implementation)
- [ ] Device testing on Moto G60s (pending WeatherScreen)

### Notes
- Permission request flow will be integrated in WeatherViewModel (S2.3)
- Full end-to-end testing pending WeatherScreen UI
- Code is ready for use by any ViewModel needing location