### PR TITLE
feat: Add unit tests for SettingsManager (S5.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,8 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.mockk:mockk:1.13.8")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))

--- a/app/src/test/kotlin/com/giruai/climatest/data/local/preferences/SettingsManagerTest.kt
+++ b/app/src/test/kotlin/com/giruai/climatest/data/local/preferences/SettingsManagerTest.kt
@@ -1,0 +1,95 @@
+package com.giruai.climatest.data.local.preferences
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var settingsManager: SettingsManager
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        settingsManager = SettingsManager(context)
+    }
+
+    @After
+    fun tearDown() {
+        // Clear preferences after each test
+        context.getSharedPreferences("clima_settings", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun `settings default to Celsius and KMH`() = runTest {
+        val settings = settingsManager.settings.first()
+        
+        assertEquals(TemperatureUnit.CELSIUS, settings.temperatureUnit)
+        assertEquals(WindUnit.KMH, settings.windUnit)
+    }
+
+    @Test
+    fun `setTemperatureUnit updates settings flow`() = runTest {
+        settingsManager.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
+        
+        val settings = settingsManager.settings.first()
+        assertEquals(TemperatureUnit.FAHRENHEIT, settings.temperatureUnit)
+    }
+
+    @Test
+    fun `setWindUnit updates settings flow`() = runTest {
+        settingsManager.setWindUnit(WindUnit.MPH)
+        
+        val settings = settingsManager.settings.first()
+        assertEquals(WindUnit.MPH, settings.windUnit)
+    }
+
+    @Test
+    fun `settings persist across manager instances`() = runTest {
+        // Set preferences
+        settingsManager.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
+        settingsManager.setWindUnit(WindUnit.MPH)
+        
+        // Create new instance (simulates app restart)
+        val newManager = SettingsManager(context)
+        val settings = newManager.settings.first()
+        
+        assertEquals(TemperatureUnit.FAHRENHEIT, settings.temperatureUnit)
+        assertEquals(WindUnit.MPH, settings.windUnit)
+    }
+
+    @Test
+    fun `settings flow emits updated values on change`() = runTest {
+        val initialSettings = settingsManager.settings.first()
+        assertEquals(TemperatureUnit.CELSIUS, initialSettings.temperatureUnit)
+        
+        settingsManager.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
+        
+        val updatedSettings = settingsManager.settings.first()
+        assertEquals(TemperatureUnit.FAHRENHEIT, updatedSettings.temperatureUnit)
+    }
+
+    @Test
+    fun `temperature unit enum has correct symbols`() {
+        assertEquals("°C", TemperatureUnit.CELSIUS.symbol)
+        assertEquals("°F", TemperatureUnit.FAHRENHEIT.symbol)
+    }
+
+    @Test
+    fun `wind unit enum has correct symbols`() {
+        assertEquals("km/h", WindUnit.KMH.symbol)
+        assertEquals("mph", WindUnit.MPH.symbol)
+    }
+}


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests for the existing SettingsManager implementation.

## Changes
- **SettingsManagerTest** with 7 test cases covering all acceptance criteria
- Robolectric dependency for Android component testing
- Tests verify defaults, updates, persistence, and reactive Flow behavior

## Test Results
```
✅ settings default to Celsius and KMH
✅ setTemperatureUnit updates settings flow
✅ setWindUnit updates settings flow
✅ settings persist across manager instances
✅ settings flow emits updated values on change
✅ temperature unit enum has correct symbols
✅ wind unit enum has correct symbols
```

**7/7 tests passing**

## Acceptance Criteria (S5.1)
- [x] SettingsManager provides temperature unit (C/F)
- [x] SettingsManager provides wind unit (km/h / mph)
- [x] Settings persist across app restarts
- [x] Default: Celsius, km/h
- [x] Changes emit as Flow for reactive updates
- [x] Unit test settings persistence

## Related
- Closes #15 (S5.1: Implement Settings Manager)
- Part of Sprint 4 — Settings & Polish