### PR TITLE
feat: Apply unit conversions to weather display (S5.3)

### DIFF
--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherScreen.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherScreen.kt
@@ -20,11 +20,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.giruai.climatest.data.local.preferences.UserSettings
 import com.giruai.climatest.domain.model.CurrentWeather
 import com.giruai.climatest.domain.model.DailyForecast
 import com.giruai.climatest.presentation.components.ErrorMessage
 import com.giruai.climatest.presentation.components.LoadingIndicator
 import com.giruai.climatest.presentation.components.WeatherIcon
+import com.giruai.climatest.presentation.util.UnitConverter
 import com.giruai.climatest.presentation.util.rememberLocationPermissionHandler
 import java.text.SimpleDateFormat
 import java.util.*
@@ -48,6 +50,7 @@ fun WeatherScreen(
     val uiState by viewModel.uiState.collectAsState()
     val isFavorite by viewModel.isFavorite.collectAsState()
     val snackbarMessage by viewModel.snackbarMessage.collectAsState()
+    val userSettings by viewModel.userSettings.collectAsState()
     
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -139,7 +142,8 @@ fun WeatherScreen(
                         currentWeather = state.currentWeather,
                         forecast = state.forecast,
                         cityName = state.cityName,
-                        lastUpdated = state.lastUpdated
+                        lastUpdated = state.lastUpdated,
+                        userSettings = userSettings
                     )
                 }
 
@@ -172,7 +176,8 @@ private fun WeatherContent(
     currentWeather: CurrentWeather,
     forecast: List<DailyForecast>,
     cityName: String,
-    lastUpdated: Long
+    lastUpdated: Long,
+    userSettings: UserSettings
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -184,7 +189,8 @@ private fun WeatherContent(
             CurrentWeatherSection(
                 currentWeather = currentWeather,
                 cityName = cityName,
-                lastUpdated = lastUpdated
+                lastUpdated = lastUpdated,
+                userSettings = userSettings
             )
         }
 
@@ -199,7 +205,7 @@ private fun WeatherContent(
 
         // Forecast Items
         items(forecast) { day ->
-            ForecastItem(day)
+            ForecastItem(day, userSettings)
         }
     }
 }
@@ -208,7 +214,8 @@ private fun WeatherContent(
 private fun CurrentWeatherSection(
     currentWeather: CurrentWeather,
     cityName: String,
-    lastUpdated: Long
+    lastUpdated: Long,
+    userSettings: UserSettings
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -238,7 +245,7 @@ private fun CurrentWeatherSection(
 
             // Temperature (large)
             Text(
-                text = "${currentWeather.temperature.toInt()}°C",
+                text = UnitConverter.formatTemperature(currentWeather.temperature, userSettings.temperatureUnit),
                 style = MaterialTheme.typography.displayLarge,
                 color = MaterialTheme.colorScheme.primary
             )
@@ -259,11 +266,11 @@ private fun CurrentWeatherSection(
             ) {
                 WeatherDetail(
                     label = "Feels Like",
-                    value = "${currentWeather.apparentTemperature.toInt()}°C"
+                    value = UnitConverter.formatTemperature(currentWeather.apparentTemperature, userSettings.temperatureUnit)
                 )
                 WeatherDetail(
                     label = "Wind",
-                    value = "${currentWeather.windSpeed.toInt()} km/h"
+                    value = UnitConverter.formatWindSpeed(currentWeather.windSpeed, userSettings.windUnit)
                 )
                 WeatherDetail(
                     label = "Humidity",
@@ -297,7 +304,7 @@ private fun WeatherDetail(label: String, value: String) {
 }
 
 @Composable
-private fun ForecastItem(day: DailyForecast) {
+private fun ForecastItem(day: DailyForecast, userSettings: UserSettings) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
@@ -328,11 +335,11 @@ private fun ForecastItem(day: DailyForecast) {
                 modifier = Modifier.weight(1f)
             ) {
                 Text(
-                    text = "${day.temperatureMax.toInt()}°C",
+                    text = UnitConverter.formatTemperature(day.temperatureMax, userSettings.temperatureUnit),
                     style = MaterialTheme.typography.titleMedium
                 )
                 Text(
-                    text = "${day.temperatureMin.toInt()}°C",
+                    text = UnitConverter.formatTemperature(day.temperatureMin, userSettings.temperatureUnit),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherViewModel.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherViewModel.kt
@@ -2,6 +2,8 @@ package com.giruai.climatest.presentation.screen.weather
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.giruai.climatest.data.local.preferences.SettingsManager
+import com.giruai.climatest.data.local.preferences.UserSettings
 import com.giruai.climatest.domain.location.LocationProvider
 import com.giruai.climatest.domain.model.City
 import com.giruai.climatest.domain.usecase.AddFavoriteUseCase
@@ -10,8 +12,10 @@ import com.giruai.climatest.domain.usecase.GetForecastUseCase
 import com.giruai.climatest.domain.usecase.IsFavoriteUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -22,8 +26,16 @@ class WeatherViewModel @Inject constructor(
     private val getCurrentWeather: GetCurrentWeatherUseCase,
     private val getForecast: GetForecastUseCase,
     private val addFavorite: AddFavoriteUseCase,
-    private val isFavoriteUseCase: IsFavoriteUseCase
+    private val isFavoriteUseCase: IsFavoriteUseCase,
+    settingsManager: SettingsManager
 ) : ViewModel() {
+
+    val userSettings: StateFlow<UserSettings> = settingsManager.settings
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UserSettings()
+        )
 
     private val _uiState = MutableStateFlow<WeatherUiState>(WeatherUiState.Loading)
     val uiState: StateFlow<WeatherUiState> = _uiState.asStateFlow()

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/util/UnitConverter.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/util/UnitConverter.kt
@@ -1,0 +1,32 @@
+package com.giruai.climatest.presentation.util
+
+import com.giruai.climatest.data.local.preferences.TemperatureUnit
+import com.giruai.climatest.data.local.preferences.WindUnit
+import kotlin.math.roundToInt
+
+object UnitConverter {
+
+    fun convertTemperature(celsius: Double, unit: TemperatureUnit): Double {
+        return when (unit) {
+            TemperatureUnit.CELSIUS -> celsius
+            TemperatureUnit.FAHRENHEIT -> celsius * 9.0 / 5.0 + 32.0
+        }
+    }
+
+    fun formatTemperature(celsius: Double, unit: TemperatureUnit): String {
+        val converted = convertTemperature(celsius, unit)
+        return "${converted.roundToInt()}${unit.symbol}"
+    }
+
+    fun convertWindSpeed(kmh: Double, unit: WindUnit): Double {
+        return when (unit) {
+            WindUnit.KMH -> kmh
+            WindUnit.MPH -> kmh * 0.621371
+        }
+    }
+
+    fun formatWindSpeed(kmh: Double, unit: WindUnit): String {
+        val converted = convertWindSpeed(kmh, unit)
+        return "${converted.roundToInt()} ${unit.symbol}"
+    }
+}

--- a/app/src/test/kotlin/com/giruai/climatest/presentation/util/UnitConverterTest.kt
+++ b/app/src/test/kotlin/com/giruai/climatest/presentation/util/UnitConverterTest.kt
@@ -1,0 +1,59 @@
+package com.giruai.climatest.presentation.util
+
+import com.giruai.climatest.data.local.preferences.TemperatureUnit
+import com.giruai.climatest.data.local.preferences.WindUnit
+import org.junit.Assert.*
+import org.junit.Test
+
+class UnitConverterTest {
+
+    @Test
+    fun `celsius to celsius returns same value`() {
+        assertEquals(25.0, UnitConverter.convertTemperature(25.0, TemperatureUnit.CELSIUS), 0.01)
+    }
+
+    @Test
+    fun `0 celsius to fahrenheit returns 32`() {
+        assertEquals(32.0, UnitConverter.convertTemperature(0.0, TemperatureUnit.FAHRENHEIT), 0.01)
+    }
+
+    @Test
+    fun `100 celsius to fahrenheit returns 212`() {
+        assertEquals(212.0, UnitConverter.convertTemperature(100.0, TemperatureUnit.FAHRENHEIT), 0.01)
+    }
+
+    @Test
+    fun `negative celsius to fahrenheit`() {
+        assertEquals(-4.0, UnitConverter.convertTemperature(-20.0, TemperatureUnit.FAHRENHEIT), 0.01)
+    }
+
+    @Test
+    fun `formatTemperature celsius`() {
+        assertEquals("25°C", UnitConverter.formatTemperature(25.3, TemperatureUnit.CELSIUS))
+    }
+
+    @Test
+    fun `formatTemperature fahrenheit`() {
+        assertEquals("77°F", UnitConverter.formatTemperature(25.0, TemperatureUnit.FAHRENHEIT))
+    }
+
+    @Test
+    fun `kmh to kmh returns same value`() {
+        assertEquals(10.0, UnitConverter.convertWindSpeed(10.0, WindUnit.KMH), 0.01)
+    }
+
+    @Test
+    fun `kmh to mph conversion`() {
+        assertEquals(6.21, UnitConverter.convertWindSpeed(10.0, WindUnit.MPH), 0.01)
+    }
+
+    @Test
+    fun `formatWindSpeed kmh`() {
+        assertEquals("10 km/h", UnitConverter.formatWindSpeed(10.0, WindUnit.KMH))
+    }
+
+    @Test
+    fun `formatWindSpeed mph`() {
+        assertEquals("6 mph", UnitConverter.formatWindSpeed(10.0, WindUnit.MPH))
+    }
+}


### PR DESCRIPTION
## Summary
Applies user-selected unit conversions to all temperature and wind speed displays.

## Changes
- **UnitConverter** utility with temp (C→F) and wind (km/h→mph) conversions
- **10 unit tests** covering all conversion edge cases
- **WeatherViewModel** exposes userSettings StateFlow from SettingsManager
- **WeatherScreen** uses UnitConverter for main temp, feels like, wind, and forecast

## Device Testing (Moto G60s)
- ✅ 67°F displayed (was 19°C) after selecting Fahrenheit
- ✅ Feels Like: 62°F
- ✅ Forecast: all temps in °F
- ✅ Wind: 19 km/h (independent setting)
- ✅ No API refetch needed

## Acceptance Criteria (S5.3)
- [x] Temperature displays in user-selected unit
- [x] Wind speed displays in user-selected unit
- [x] Conversions accurate (F = C * 9/5 + 32, mph = km/h * 0.621)
- [x] Changes immediately update all screens
- [x] No API refetch for unit change

Closes #17