### PR TITLE
feat: Add reverse geocoding for city names (#25)

### DIFF
--- a/app/src/main/kotlin/com/giruai/climatest/data/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/data/location/ReverseGeocoder.kt
@@ -1,0 +1,74 @@
+package com.giruai.climatest.data.location
+
+import android.content.Context
+import android.location.Geocoder
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReverseGeocoder @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val cache = mutableMapOf<String, String>()
+
+    suspend fun getCityName(latitude: Double, longitude: Double): String {
+        val key = "%.2f,%.2f".format(latitude, longitude)
+
+        // Check cache first
+        cache[key]?.let { return it }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val geocoder = Geocoder(context, Locale.getDefault())
+                @Suppress("DEPRECATION")
+                val addresses = geocoder.getFromLocation(latitude, longitude, 1)
+                val address = addresses?.firstOrNull()
+
+                // Pick best available name, preferring human-readable city names
+                val bestName = when {
+                    address == null -> null
+                    else -> {
+                        val locality = address.locality
+                        val subAdmin = address.subAdminArea
+                        val admin = address.adminArea
+                        val country = address.countryCode
+
+                        // Filter out non-city-name values
+                        val isPostalCode = locality != null && locality.matches(Regex("^[A-Z]?\\d.*"))
+                        val isGenericDistrict = subAdmin != null && subAdmin.matches(Regex("^(Comuna|District|Ward|Sector)\\s.*", RegexOption.IGNORE_CASE))
+
+                        val cityPart = when {
+                            locality != null && !isPostalCode -> locality
+                            subAdmin != null && !isGenericDistrict -> subAdmin
+                            admin != null -> admin
+                            subAdmin != null -> subAdmin  // fallback to generic district
+                            locality != null -> locality  // fallback to postal code
+                            else -> null
+                        }
+
+                        if (cityPart != null && country != null) "$cityPart, $country"
+                        else if (cityPart != null) cityPart
+                        else address.countryName
+                    }
+                }
+
+                val cityName = bestName
+
+                cityName?.also { cache[key] = it }
+                    ?: formatCoordinates(latitude, longitude)
+            } catch (e: Exception) {
+                Timber.w(e, "Reverse geocoding failed for $key")
+                formatCoordinates(latitude, longitude)
+            }
+        }
+    }
+
+    private fun formatCoordinates(latitude: Double, longitude: Double): String {
+        return "%.2f°, %.2f°".format(latitude, longitude)
+    }
+}

--- a/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherViewModel.kt
+++ b/app/src/main/kotlin/com/giruai/climatest/presentation/screen/weather/WeatherViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.giruai.climatest.data.local.preferences.SettingsManager
 import com.giruai.climatest.data.local.preferences.UserSettings
+import com.giruai.climatest.data.location.ReverseGeocoder
 import com.giruai.climatest.domain.location.LocationProvider
 import com.giruai.climatest.domain.model.City
 import com.giruai.climatest.domain.usecase.AddFavoriteUseCase
@@ -27,6 +28,7 @@ class WeatherViewModel @Inject constructor(
     private val getForecast: GetForecastUseCase,
     private val addFavorite: AddFavoriteUseCase,
     private val isFavoriteUseCase: IsFavoriteUseCase,
+    private val reverseGeocoder: ReverseGeocoder,
     settingsManager: SettingsManager
 ) : ViewModel() {
 
@@ -98,7 +100,7 @@ class WeatherViewModel @Inject constructor(
                     // Fetch forecast
                     val forecastResult = getForecast(latitude, longitude)
                     forecastResult.onSuccess { forecast ->
-                        val cityName = formatCityName(latitude, longitude)
+                        val cityName = reverseGeocoder.getCityName(latitude, longitude)
                         _uiState.value = WeatherUiState.Success(
                             currentWeather = currentWeather,
                             forecast = forecast,
@@ -106,11 +108,16 @@ class WeatherViewModel @Inject constructor(
                             lastUpdated = System.currentTimeMillis()
                         )
                         
+                        // Extract country from cityName (format: "City, CC")
+                        val parts = cityName.split(", ")
+                        val city = parts.firstOrNull() ?: cityName
+                        val country = if (parts.size > 1) parts.last() else "Unknown"
+                        
                         // Store current city for favorites
                         currentCity = City(
                             id = generateCityId(latitude, longitude),
-                            name = cityName,
-                            country = "Unknown", // Will be improved with reverse geocoding
+                            name = city,
+                            country = country,
                             latitude = latitude,
                             longitude = longitude
                         )
@@ -140,12 +147,6 @@ class WeatherViewModel @Inject constructor(
     fun refresh() {
         Timber.d("Refreshing weather data")
         loadWeather()
-    }
-
-    private fun formatCityName(latitude: Double, longitude: Double): String {
-        // TODO: Implement reverse geocoding for proper city name
-        // For now, show coordinates or "Current Location"
-        return String.format("%.2f°, %.2f°", latitude, longitude)
     }
 
     private fun checkIfFavorite() {

--- a/app/src/test/kotlin/com/giruai/climatest/data/location/ReverseGeocoderTest.kt
+++ b/app/src/test/kotlin/com/giruai/climatest/data/location/ReverseGeocoderTest.kt
@@ -1,0 +1,134 @@
+package com.giruai.climatest.data.location
+
+import android.content.Context
+import android.location.Address
+import android.location.Geocoder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.IOException
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class ReverseGeocoderTest {
+
+    private lateinit var context: Context
+    private lateinit var reverseGeocoder: ReverseGeocoder
+
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        reverseGeocoder = ReverseGeocoder(context)
+    }
+
+    @Test
+    fun `formatCoordinates returns correct format`() = runTest {
+        // When geocoder is not available, falls back to coordinates
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } returns emptyList()
+
+        val result = reverseGeocoder.getCityName(-34.6037, -58.3816)
+        assertEquals("-34.60°, -58.38°", result)
+    }
+
+    @Test
+    fun `getCityName returns city and country when available`() = runTest {
+        val address = mockk<Address>()
+        every { address.locality } returns "Buenos Aires"
+        every { address.countryCode } returns "AR"
+        every { address.subAdminArea } returns null
+        every { address.adminArea } returns null
+        every { address.countryName } returns "Argentina"
+
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } returns listOf(address)
+
+        val result = reverseGeocoder.getCityName(-34.6037, -58.3816)
+        assertEquals("Buenos Aires, AR", result)
+    }
+
+    @Test
+    fun `getCityName falls back to coords on IOException`() = runTest {
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } throws IOException("Network error")
+
+        val result = reverseGeocoder.getCityName(48.8566, 2.3522)
+        assertEquals("48.86°, 2.35°", result)
+    }
+
+    @Test
+    fun `getCityName uses cache on second call`() = runTest {
+        val address = mockk<Address>()
+        every { address.locality } returns "Paris"
+        every { address.countryCode } returns "FR"
+        every { address.subAdminArea } returns null
+        every { address.adminArea } returns null
+        every { address.countryName } returns "France"
+
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } returns listOf(address)
+
+        // First call
+        val result1 = reverseGeocoder.getCityName(48.8566, 2.3522)
+        assertEquals("Paris, FR", result1)
+
+        // Second call should use cache (even if geocoder throws)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } throws IOException("Should not be called")
+        val result2 = reverseGeocoder.getCityName(48.8566, 2.3522)
+        assertEquals("Paris, FR", result2)
+    }
+
+    @Test
+    fun `getCityName falls back to adminArea when locality is null`() = runTest {
+        val address = mockk<Address>()
+        every { address.locality } returns null
+        every { address.countryCode } returns "US"
+        every { address.subAdminArea } returns null
+        every { address.adminArea } returns "California"
+        every { address.countryName } returns "United States"
+
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } returns listOf(address)
+
+        val result = reverseGeocoder.getCityName(37.7749, -122.4194)
+        assertEquals("California, US", result)
+    }
+
+    @Test
+    fun `getCityName skips postal code locality and uses subAdminArea`() = runTest {
+        val address = mockk<Address>()
+        every { address.locality } returns "C1070AAJ"  // Argentine postal code
+        every { address.countryCode } returns "AR"
+        every { address.subAdminArea } returns "Buenos Aires"
+        every { address.adminArea } returns "Ciudad Autónoma de Buenos Aires"
+        every { address.countryName } returns "Argentina"
+
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } returns listOf(address)
+
+        val result = reverseGeocoder.getCityName(-34.6037, -58.3816)
+        assertEquals("Buenos Aires, AR", result)
+    }
+
+    @Test
+    fun `getCityName skips generic district and uses adminArea`() = runTest {
+        val address = mockk<Address>()
+        every { address.locality } returns "C1070AAJ"  // Argentine postal code
+        every { address.countryCode } returns "AR"
+        every { address.subAdminArea } returns "Comuna 1"  // Generic district
+        every { address.adminArea } returns "Ciudad Autónoma de Buenos Aires"
+        every { address.countryName } returns "Argentina"
+
+        mockkConstructor(Geocoder::class)
+        every { anyConstructed<Geocoder>().getFromLocation(any(), any(), any()) } returns listOf(address)
+
+        val result = reverseGeocoder.getCityName(-34.6037, -58.3816)
+        assertEquals("Ciudad Autónoma de Buenos Aires, AR", result)
+    }
+}


### PR DESCRIPTION
## Summary
Replace coordinates ("-34.60°, -58.38°") with human-readable city names ("Buenos Aires, AR") using Android's built-in Geocoder API.

## Changes

### ReverseGeocoder (New)
- Android Geocoder API for lat/lon → city name conversion
- In-memory cache to avoid repeated API calls for same coordinates
- Smart name selection: skips postal codes (e.g., C1070AAJ) and generic districts (e.g., Comuna 1)
- Fallback chain: locality → subAdminArea → adminArea → coordinates
- Graceful error handling: falls back to coordinates on any exception

### WeatherViewModel (Updated)
- Injected ReverseGeocoder dependency
- Replaced hardcoded `formatCityName()` with `reverseGeocoder.getCityName()`
- City/country properly extracted for favorites storage

## Test Results (7/7 passing)
- ✅ Default coords fallback
- ✅ City + country extraction ("Buenos Aires, AR")
- ✅ IOException fallback to coords
- ✅ Cache on repeated calls
- ✅ AdminArea fallback when locality is null
- ✅ Postal code filtering (Argentine CPA codes)
- ✅ Generic district filtering ("Comuna 1" → "Ciudad Autónoma de Buenos Aires")

## Device Testing (Moto G60s)
- ✅ Search 'Buenos Aires' → Weather card shows **"Buenos Aires, AR"**
- ✅ Previously showed "-34.60°, -58.38°" or "C1070AAJ, AR"

## Acceptance Criteria
- [x] Implement reverse geocoding API integration
- [x] Update WeatherViewModel to return actual city name
- [x] Handle geocoding failures gracefully (fallback to coords)
- [x] Cache city names to avoid repeated API calls
- [x] Test on device with multiple locations

Closes #25